### PR TITLE
Add Pester tests and enhance automation runbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .vscode
 automation/tests/*Testing.ps1
 .fake
-automation/Get-SentinelPricing.ps1
 **/TestResults*.xml
 **/coverage*.xml
 __azurite_db*.json

--- a/automation/Get-AzurePolicies.ps1
+++ b/automation/Get-AzurePolicies.ps1
@@ -1,0 +1,829 @@
+#Requires -Version 7.0
+
+<#
+Disclaimer: This script is provided "as-is" without warranty of any kind. Use at your own risk. The author is not liable for any damage or loss resulting from the use of this script.
+
+This script was not developed or tested by the repo owner. It was contributed by a community member and is provided for reference and educational purposes. Please review and test the script in a non-production environment before using it in production.
+
+I do not have the code for the logic app that this runbook posts to, but the general idea is:
+- This runbook is triggered on a schedule (e.g., daily) in Azure Automation.
+- It retrieves the policy assignments and definitions for a given Azure subscription.
+- It posts this information to a Logic App endpoint, which can then log it, send notifications, or take other actions based on the policy inventory.
+
+
+.SYNOPSIS
+Collects Azure Policy assignments and definitions for a subscription and posts the inventory to a Logic App endpoint.
+
+.DESCRIPTION
+This Azure Automation runbook:
+- Resolves all inputs from parameters first, then environment variables, then Automation variables.
+- Validates all required inputs before any Azure call.
+- Authenticates using a user-assigned managed identity (UAMI) only.
+- Enumerates policy assignments at subscription scope.
+- Resolves each assignment to its policy definition or policy set (initiative) definition.
+- Posts a JSON inventory payload to a Logic App endpoint with retry and backoff.
+- Emits a structured summary object for downstream automation and auditing.
+
+The default payload is a slim summary (no policyRule bodies). Use -IncludePolicyRule
+to include the full policyRule for each definition.
+
+Automation variable names used when parameters are omitted:
+- UMI_ID (or UMI_CLIENT_ID)
+- SUBSCRIPTION_ID
+- WORKSPACE_NAME
+- POLICYMONITORING_API
+
+UAMI role requirements (minimum):
+- Reader at subscription scope (covers policy assignment and definition read operations)
+
+.PARAMETER UmiClientId
+User-assigned managed identity client ID (GUID). Alias: UMIId.
+
+.PARAMETER SubscriptionId
+Azure subscription ID (GUID). Alias: SubscriptionID.
+
+.PARAMETER WorkspaceName
+Sentinel Log Analytics workspace name. Alias: workspaceName.
+
+.PARAMETER LogicAppUri
+Logic App HTTP endpoint URI (HTTPS with SAS token) to post the policy inventory payload.
+Alias: policyMonitoringApi.
+
+.PARAMETER IncludePolicyRule
+When specified, includes the full policyRule body in each definition output object.
+By default the policyRule is omitted to reduce payload size.
+
+.PARAMETER VerboseLogging
+When specified, enables verbose-level log output for troubleshooting.
+
+.EXAMPLE
+.\Get-AzurePolicies.ps1 `
+  -UmiClientId '11111111-1111-1111-1111-111111111111' `
+  -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+  -WorkspaceName 'law-sentinel-eastus' `
+  -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/.../triggers/manual/paths/invoke?...&sig=...'
+
+Collects all policy assignments and definitions for the subscription and posts
+the slim inventory to the specified Logic App.
+
+.EXAMPLE
+.\Get-AzurePolicies.ps1 `
+  -UmiClientId '11111111-1111-1111-1111-111111111111' `
+  -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+  -WorkspaceName 'law-sentinel-eastus' `
+  -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/...' `
+  -IncludePolicyRule
+
+Same as above but includes the full policyRule body in each definition object.
+
+.NOTES
+Logic App URI handling: The URI is treated as a secret (SAS token in query string).
+Only the host portion is ever logged. The full URI never appears in output, warning,
+or verbose streams.
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+  [Parameter()]
+  [Alias('UMIId')]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $UmiClientId,
+
+  [Parameter()]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $SubscriptionId,
+
+  [Parameter()]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $WorkspaceName,
+
+  [Parameter()]
+  [Alias('policyMonitoringApi')]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $LogicAppUri,
+
+  [Parameter()]
+  [switch]
+  $IncludePolicyRule,
+
+  [Parameter()]
+  [switch]
+  $VerboseLogging
+)
+
+# ============================================================================
+# SCRIPT INITIALIZATION
+# ============================================================================
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$script:RunbookVersion = '1.0.0'
+
+# ============================================================================
+# HELPER FUNCTIONS
+# ============================================================================
+
+<#
+.SYNOPSIS
+Safely retrieves an Azure Automation variable without throwing if unavailable.
+
+.PARAMETER Name
+The name of the Automation variable to retrieve.
+#>
+function Get-AutomationVariableSafe {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Name
+  )
+
+  $command = Get-Command -Name 'Get-AutomationVariable' -ErrorAction SilentlyContinue
+  if (-not $command) {
+    return $null
+  }
+
+  try {
+    return Get-AutomationVariable -Name $Name
+  }
+  catch {
+    Write-Verbose "Failed to read Automation variable '$Name': $($_.Exception.Message)"
+    return $null
+  }
+}
+
+<#
+.SYNOPSIS
+Resolves a configuration value from multiple sources in priority order.
+
+.DESCRIPTION
+Cascading resolution: parameter > environment variable > Automation variable.
+
+.PARAMETER parameterValue
+The value passed as a script parameter.
+
+.PARAMETER environmentVariableNames
+Array of environment/Automation variable names to check in order.
+
+.PARAMETER parameterName
+Friendly parameter name for error messages.
+#>
+function Resolve-ConfiguredValue {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [AllowNull()]
+    [string]
+    $parameterValue,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string[]]
+    $environmentVariableNames,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $parameterName
+  )
+
+  if (-not [string]::IsNullOrWhiteSpace($parameterValue)) {
+    return $parameterValue.Trim()
+  }
+
+  foreach ($envName in $environmentVariableNames) {
+    $envValue = [Environment]::GetEnvironmentVariable($envName)
+    if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+      return $envValue.Trim()
+    }
+  }
+
+  foreach ($autoName in $environmentVariableNames) {
+    $autoValue = Get-AutomationVariableSafe -Name $autoName
+    if (-not [string]::IsNullOrWhiteSpace($autoValue)) {
+      return ([string]$autoValue).Trim()
+    }
+  }
+
+  throw "Missing required value '$parameterName'. Provide parameter '$parameterName' or set one of: $($environmentVariableNames -join ', ')."
+}
+
+<#
+.SYNOPSIS
+Validates that a string is a properly formatted GUID.
+
+.PARAMETER value
+The string to validate.
+
+.PARAMETER parameterName
+Friendly parameter name for error messages.
+#>
+function Assert-ValidGuid {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $value,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $parameterName
+  )
+
+  $trimmed = $value.Trim()
+  if ($trimmed -notmatch '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
+    throw "$parameterName must be a valid GUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)."
+  }
+}
+
+<#
+.SYNOPSIS
+Validates that a URI uses HTTPS scheme.
+
+.PARAMETER uri
+The URI string to validate.
+
+.PARAMETER parameterName
+Friendly parameter name for error messages.
+#>
+function Test-IsHttpsUri {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $uri,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $parameterName
+  )
+
+  try {
+    $parsed = [Uri]::new($uri)
+  }
+  catch {
+    throw "$parameterName is not a valid URI."
+  }
+
+  if ($parsed.Scheme -ne 'https') {
+    throw "$parameterName must use HTTPS scheme. Received scheme: '$($parsed.Scheme)'."
+  }
+}
+
+<#
+.SYNOPSIS
+Extracts only the host portion of a URI for safe logging.
+
+.DESCRIPTION
+Logic App URIs contain SAS tokens in the query string. This function returns
+only the host so the full URI (including secrets) is never logged.
+
+.PARAMETER uri
+The full URI string.
+#>
+function Get-UriHostForLog {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $uri
+  )
+
+  try {
+    return ([Uri]::new($uri)).Host
+  }
+  catch {
+    return '(invalid-uri)'
+  }
+}
+
+<#
+.SYNOPSIS
+Masks a string for safe logging, showing only the last 4 characters.
+
+.PARAMETER value
+The string to mask.
+#>
+function Get-MaskedValue {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $value
+  )
+
+  if ($value.Length -le 4) {
+    return '****'
+  }
+  return "$('*' * ($value.Length - 4))$($value.Substring($value.Length - 4))"
+}
+
+<#
+.SYNOPSIS
+Writes a structured log message with RunId, timestamp, and severity level.
+
+.PARAMETER Level
+Log level: INFO, WARN, ERROR, VERBOSE.
+
+.PARAMETER Message
+The message to log.
+#>
+function Write-Log {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('INFO', 'WARN', 'ERROR', 'VERBOSE')]
+    [string]
+    $Level,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Message
+  )
+
+  $timestamp = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
+  $formatted = "[$timestamp] [$Level] [RunId=$($script:RunId)] $Message"
+
+  switch ($Level) {
+    'INFO'    { Write-Information $formatted -InformationAction Continue }
+    'WARN'    { Write-Warning $formatted }
+    'ERROR'   { Write-Error $formatted -ErrorAction Continue }
+    'VERBOSE' {
+      if ($script:EnableVerboseLogging) {
+        Write-Information $formatted -InformationAction Continue
+      }
+      else {
+        Write-Verbose $formatted
+      }
+    }
+  }
+}
+
+<#
+.SYNOPSIS
+StrictMode-safe property access for objects with varying shapes.
+
+.PARAMETER inputObject
+The object to read from.
+
+.PARAMETER propertyName
+The property name to read.
+#>
+function Get-OptionalPropertyValue {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [AllowNull()]
+    [object]
+    $inputObject,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $propertyName
+  )
+
+  if ($null -eq $inputObject) {
+    return $null
+  }
+
+  $prop = $inputObject.PSObject.Properties[$propertyName]
+  if ($null -eq $prop) {
+    return $null
+  }
+
+  return $prop.Value
+}
+
+<#
+.SYNOPSIS
+Executes a script block with retry logic for transient failures.
+
+.PARAMETER operationName
+Friendly name for logging.
+
+.PARAMETER scriptBlock
+The code to execute.
+
+.PARAMETER maximumAttempts
+Maximum number of attempts.
+
+.PARAMETER initialDelaySeconds
+Base delay in seconds, multiplied by attempt number.
+#>
+function Invoke-WithRetry {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $operationName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNull()]
+    [scriptblock]
+    $scriptBlock,
+
+    [Parameter()]
+    [ValidateRange(1, 10)]
+    [int]
+    $maximumAttempts = 3,
+
+    [Parameter()]
+    [ValidateRange(1, 120)]
+    [int]
+    $initialDelaySeconds = 2
+  )
+
+  for ($attempt = 1; $attempt -le $maximumAttempts; $attempt++) {
+    try {
+      return & $scriptBlock
+    }
+    catch {
+      $statusCode = $null
+      if ($_.Exception -and $_.Exception.PSObject.Properties['Response']) {
+        try {
+          $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+        catch {
+          $statusCode = $null
+        }
+      }
+
+      $isTransient = ($null -eq $statusCode -or $statusCode -eq 429 -or ($statusCode -ge 500 -and $statusCode -le 599))
+
+      if (-not $isTransient -or $attempt -ge $maximumAttempts) {
+        throw
+      }
+
+      $delaySeconds = [Math]::Min($initialDelaySeconds * $attempt, 30)
+      Write-Log -Level WARN -Message "Operation '$operationName' failed (attempt $attempt/$maximumAttempts). Retrying in $($delaySeconds)s. Error: $($_.Exception.Message)"
+      Start-Sleep -Seconds $delaySeconds
+    }
+  }
+}
+
+<#
+.SYNOPSIS
+Posts a JSON body to a URI with retry logic for transient failures.
+
+.PARAMETER uri
+The target URI.
+
+.PARAMETER body
+The JSON body string.
+
+.PARAMETER maxAttempts
+Maximum retry attempts.
+
+.PARAMETER timeoutSec
+HTTP timeout in seconds.
+#>
+function Invoke-RestMethodWithRetry {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $uri,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $body,
+
+    [Parameter()]
+    [ValidateRange(1, 10)]
+    [int]
+    $maxAttempts = 5,
+
+    [Parameter()]
+    [ValidateRange(1, 300)]
+    [int]
+    $timeoutSec = 60
+  )
+
+  for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+    try {
+      return Invoke-RestMethod -Method Post -Uri $uri -Body $body -ContentType 'application/json' -TimeoutSec $timeoutSec
+    }
+    catch {
+      $ex = $_.Exception
+      $statusCode = $null
+      $retryAfterSec = $null
+
+      if ($ex.PSObject.Properties.Name -contains 'Response' -and $null -ne $ex.Response) {
+        try { $statusCode = [int]$ex.Response.StatusCode } catch { $statusCode = $null }
+        try {
+          $retryAfterHeader = $ex.Response.Headers['Retry-After']
+          if (-not [string]::IsNullOrWhiteSpace($retryAfterHeader)) {
+            $retryAfterSec = [int]$retryAfterHeader
+          }
+        }
+        catch { $retryAfterSec = $null }
+      }
+
+      $isTransient = ($statusCode -eq 429 -or ($statusCode -ge 500 -and $statusCode -le 599) -or $null -eq $statusCode)
+      if (-not $isTransient -or $attempt -ge $maxAttempts) {
+        throw
+      }
+
+      $baseDelay = [Math]::Min(2 * $attempt, 10)
+      $delaySec = if ($null -ne $retryAfterSec -and $retryAfterSec -ge 1) { $retryAfterSec } else { $baseDelay }
+      Write-Log -Level WARN -Message "POST to Logic App failed (statusCode=$statusCode, attempt $attempt/$maxAttempts). Retrying in $($delaySec)s."
+      Start-Sleep -Seconds $delaySec
+    }
+  }
+}
+
+# ============================================================================
+# MAIN FUNCTION
+# ============================================================================
+
+<#
+.SYNOPSIS
+Core orchestration function for collecting and posting Azure Policy inventory.
+
+.DESCRIPTION
+Performs the complete workflow:
+1. Resolves all configuration from parameters, environment, or Automation variables
+2. Validates all inputs
+3. Authenticates with user-assigned managed identity
+4. Enumerates policy assignments at subscription scope
+5. Resolves each assignment to its policy definition or policy set definition
+6. Posts the inventory payload to a Logic App endpoint
+7. Returns a structured summary object
+#>
+function Invoke-AzurePolicyInventory {
+  [CmdletBinding(SupportsShouldProcess = $true)]
+  param(
+    [Parameter()] [string] $UmiClientId,
+    [Parameter()] [string] $SubscriptionId,
+    [Parameter()] [string] $WorkspaceName,
+    [Parameter()] [string] $LogicAppUri,
+    [Parameter()] [switch] $IncludePolicyRule,
+    [Parameter()] [switch] $VerboseLogging
+  )
+
+  # Generate RunId for correlation
+  $script:RunId = [Guid]::NewGuid().ToString()
+  $script:EnableVerboseLogging = $VerboseLogging.IsPresent -or $env:AZLH_VERBOSE_LOGGING -eq '1'
+  $runStartUtc = [DateTime]::UtcNow
+
+  Write-Log -Level INFO -Message "Starting Azure Policy inventory (version $($script:RunbookVersion))."
+
+  # -------------------------------------------------------------------
+  # STEP 1: Resolve configuration
+  # -------------------------------------------------------------------
+
+  $resolvedUmiClientId = Resolve-ConfiguredValue -parameterValue $UmiClientId -environmentVariableNames @('UMI_ID', 'UMI_CLIENT_ID') -parameterName 'UmiClientId'
+  $resolvedSubscriptionId = Resolve-ConfiguredValue -parameterValue $SubscriptionId -environmentVariableNames @('SUBSCRIPTION_ID') -parameterName 'SubscriptionId'
+  $resolvedWorkspaceName = Resolve-ConfiguredValue -parameterValue $WorkspaceName -environmentVariableNames @('WORKSPACE_NAME') -parameterName 'WorkspaceName'
+  $resolvedLogicAppUri = Resolve-ConfiguredValue -parameterValue $LogicAppUri -environmentVariableNames @('POLICYMONITORING_API') -parameterName 'LogicAppUri'
+
+  # -------------------------------------------------------------------
+  # STEP 2: Validate inputs
+  # -------------------------------------------------------------------
+
+  Assert-ValidGuid -value $resolvedUmiClientId -parameterName 'UmiClientId'
+  Assert-ValidGuid -value $resolvedSubscriptionId -parameterName 'SubscriptionId'
+  Test-IsHttpsUri -uri $resolvedLogicAppUri -parameterName 'LogicAppUri'
+
+  $logicAppHost = Get-UriHostForLog -uri $resolvedLogicAppUri
+  Write-Log -Level INFO -Message "Configuration validated. Subscription=$(Get-MaskedValue $resolvedSubscriptionId), UMI=$(Get-MaskedValue $resolvedUmiClientId), Workspace=$resolvedWorkspaceName, LogicAppHost=$logicAppHost"
+
+  # -------------------------------------------------------------------
+  # STEP 3: Authenticate
+  # -------------------------------------------------------------------
+
+  Write-Log -Level INFO -Message 'Authenticating to Azure (managed identity).'
+  Connect-AzAccount -Identity -AccountId $resolvedUmiClientId -ErrorAction Stop | Out-Null
+  Set-AzContext -SubscriptionId $resolvedSubscriptionId -ErrorAction Stop | Out-Null
+
+  # -------------------------------------------------------------------
+  # STEP 4: Enumerate policy assignments
+  # -------------------------------------------------------------------
+
+  $scope = "/subscriptions/$resolvedSubscriptionId"
+  Write-Log -Level INFO -Message "Retrieving policy assignments at scope: $scope"
+
+  $rawAssignments = Invoke-WithRetry -operationName 'Get-AzPolicyAssignment' -scriptBlock {
+    Get-AzPolicyAssignment -Scope $scope -ErrorAction Stop
+  }
+
+  if ($null -eq $rawAssignments) {
+    $rawAssignments = @()
+  }
+
+  Write-Log -Level INFO -Message "Found $(@($rawAssignments).Count) policy assignment(s)."
+
+  # -------------------------------------------------------------------
+  # STEP 5: Process assignments and resolve definitions
+  # -------------------------------------------------------------------
+
+  $assignmentResults = [System.Collections.Generic.List[PSCustomObject]]::new()
+  $definitionCache = @{}
+  $policySetCache = @{}
+  $definitionResults = [System.Collections.Generic.List[PSCustomObject]]::new()
+  $policySetResults = [System.Collections.Generic.List[PSCustomObject]]::new()
+  $failedDefinitionCount = 0
+
+  foreach ($assignment in @($rawAssignments)) {
+    $assignmentName = Get-OptionalPropertyValue -inputObject $assignment -propertyName 'Name'
+    $assignmentDisplayName = Get-OptionalPropertyValue -inputObject $assignment -propertyName 'DisplayName'
+    $policyDefId = Get-OptionalPropertyValue -inputObject $assignment -propertyName 'PolicyDefinitionId'
+    $enforcementMode = Get-OptionalPropertyValue -inputObject $assignment -propertyName 'EnforcementMode'
+    $assignmentScope = Get-OptionalPropertyValue -inputObject $assignment -propertyName 'Scope'
+    $assignmentParams = Get-OptionalPropertyValue -inputObject $assignment -propertyName 'Parameters'
+
+    # Determine assignment type
+    $assignmentType = 'Unknown'
+    if (-not [string]::IsNullOrWhiteSpace($policyDefId)) {
+      if ($policyDefId -match '/policySetDefinitions/') {
+        $assignmentType = 'PolicySetDefinition'
+      }
+      elseif ($policyDefId -match '/policyDefinitions/') {
+        $assignmentType = 'PolicyDefinition'
+      }
+    }
+
+    $assignmentObj = [PSCustomObject]@{
+      AssignmentName    = $assignmentName
+      DisplayName       = $assignmentDisplayName
+      AssignmentType    = $assignmentType
+      PolicyDefinitionId = $policyDefId
+      EnforcementMode   = $enforcementMode
+      Scope             = $assignmentScope
+      Parameters        = $assignmentParams
+    }
+    $assignmentResults.Add($assignmentObj)
+
+    if ([string]::IsNullOrWhiteSpace($policyDefId)) {
+      Write-Log -Level WARN -Message "Skipping assignment '$assignmentName' - PolicyDefinitionId is empty."
+      continue
+    }
+
+    # Resolve policy definition or policy set definition
+    if ($assignmentType -eq 'PolicySetDefinition') {
+      if (-not $policySetCache.ContainsKey($policyDefId)) {
+        try {
+          $policySet = Invoke-WithRetry -operationName "Get-AzPolicySetDefinition ($assignmentName)" -scriptBlock {
+            Get-AzPolicySetDefinition -Id $policyDefId -ErrorAction Stop
+          }
+          $policySetObj = [PSCustomObject]@{
+            PolicySetName      = Get-OptionalPropertyValue -inputObject $policySet -propertyName 'Name'
+            DisplayName        = Get-OptionalPropertyValue -inputObject $policySet -propertyName 'DisplayName'
+            PolicySetDefinitionId = $policyDefId
+            PolicyType         = Get-OptionalPropertyValue -inputObject $policySet -propertyName 'PolicyType'
+            Description        = Get-OptionalPropertyValue -inputObject $policySet -propertyName 'Description'
+            LastModifiedBy     = Get-OptionalPropertyValue -inputObject $policySet -propertyName 'SystemDataLastModifiedBy'
+            LastModifiedOn     = Get-OptionalPropertyValue -inputObject $policySet -propertyName 'SystemDataLastModifiedAt'
+          }
+          $policySetResults.Add($policySetObj)
+          $policySetCache[$policyDefId] = $true
+        }
+        catch {
+          $failedDefinitionCount++
+          Write-Log -Level WARN -Message "Failed to resolve policy set definition for assignment '$assignmentName': $($_.Exception.Message)"
+          $policySetCache[$policyDefId] = $false
+        }
+      }
+    }
+    elseif ($assignmentType -eq 'PolicyDefinition') {
+      if (-not $definitionCache.ContainsKey($policyDefId)) {
+        try {
+          $definition = Invoke-WithRetry -operationName "Get-AzPolicyDefinition ($assignmentName)" -scriptBlock {
+            Get-AzPolicyDefinition -Id $policyDefId -ErrorAction Stop
+          }
+          $defObj = [PSCustomObject]@{
+            PolicyName         = Get-OptionalPropertyValue -inputObject $definition -propertyName 'Name'
+            DisplayName        = Get-OptionalPropertyValue -inputObject $definition -propertyName 'DisplayName'
+            PolicyDefinitionId = $policyDefId
+            PolicyType         = Get-OptionalPropertyValue -inputObject $definition -propertyName 'PolicyType'
+            Description        = Get-OptionalPropertyValue -inputObject $definition -propertyName 'Description'
+            LastModifiedBy     = Get-OptionalPropertyValue -inputObject $definition -propertyName 'SystemDataLastModifiedBy'
+            LastModifiedOn     = Get-OptionalPropertyValue -inputObject $definition -propertyName 'SystemDataLastModifiedAt'
+          }
+          if ($IncludePolicyRule.IsPresent) {
+            $policyRule = Get-OptionalPropertyValue -inputObject $definition -propertyName 'PolicyRule'
+            $defObj | Add-Member -NotePropertyName 'PolicyRule' -NotePropertyValue $policyRule
+          }
+          $definitionResults.Add($defObj)
+          $definitionCache[$policyDefId] = $true
+        }
+        catch {
+          $failedDefinitionCount++
+          Write-Log -Level WARN -Message "Failed to resolve policy definition for assignment '$assignmentName': $($_.Exception.Message)"
+          $definitionCache[$policyDefId] = $false
+        }
+      }
+    }
+  }
+
+  Write-Log -Level INFO -Message "Resolved $($definitionResults.Count) policy definition(s), $($policySetResults.Count) policy set definition(s), $failedDefinitionCount failed lookup(s)."
+
+  # -------------------------------------------------------------------
+  # STEP 6: Build and POST payload
+  # -------------------------------------------------------------------
+
+  $payload = @{
+    RunId               = $script:RunId
+    CurrentSubscription = $resolvedSubscriptionId
+    WorkspaceName       = $resolvedWorkspaceName
+    Scope               = $scope
+    PolicyAssignments   = @($assignmentResults)
+    PolicyDefinitions   = @($definitionResults)
+    PolicySetDefinitions = @($policySetResults)
+    FailedDefinitionLookups = $failedDefinitionCount
+  }
+
+  $jsonBody = $payload | ConvertTo-Json -Depth 20
+
+  Write-Log -Level VERBOSE -Message "Payload size: $($jsonBody.Length) characters, $($assignmentResults.Count) assignment(s)."
+
+  $postStatus = 'NotAttempted'
+  $postHttpStatus = $null
+
+  if ($PSCmdlet.ShouldProcess($logicAppHost, 'Post Azure Policy inventory')) {
+    try {
+      Write-Log -Level INFO -Message "Posting inventory to Logic App host: $logicAppHost"
+      Invoke-RestMethodWithRetry -uri $resolvedLogicAppUri -body $jsonBody | Out-Null
+      $postStatus = 'Success'
+      Write-Log -Level INFO -Message 'Logic App POST succeeded.'
+    }
+    catch {
+      $postStatus = 'Failed'
+      $postHttpStatus = $null
+      if ($_.Exception -and $_.Exception.PSObject.Properties['Response']) {
+        try { $postHttpStatus = [int]$_.Exception.Response.StatusCode } catch { $postHttpStatus = $null }
+      }
+      Write-Log -Level ERROR -Message "Logic App POST failed (httpStatus=$postHttpStatus): $($_.Exception.Message)"
+    }
+  }
+  else {
+    $postStatus = 'Skipped (WhatIf)'
+    Write-Log -Level INFO -Message 'Logic App POST skipped (-WhatIf).'
+  }
+
+  # -------------------------------------------------------------------
+  # STEP 7: Emit structured summary
+  # -------------------------------------------------------------------
+
+  $runEndUtc = [DateTime]::UtcNow
+  $durationSec = [Math]::Round(($runEndUtc - $runStartUtc).TotalSeconds, 2)
+
+  $summary = [PSCustomObject]@{
+    RunId                   = $script:RunId
+    RunbookVersion          = $script:RunbookVersion
+    StartTimeUtc            = $runStartUtc.ToString('o')
+    EndTimeUtc              = $runEndUtc.ToString('o')
+    DurationSeconds         = $durationSec
+    SubscriptionId          = $resolvedSubscriptionId
+    Scope                   = $scope
+    WorkspaceName           = $resolvedWorkspaceName
+    AssignmentCount         = $assignmentResults.Count
+    PolicyDefinitionCount   = $definitionResults.Count
+    PolicySetDefinitionCount = $policySetResults.Count
+    FailedDefinitionLookups = $failedDefinitionCount
+    IncludedPolicyRule      = $IncludePolicyRule.IsPresent
+    LogicAppHost            = $logicAppHost
+    PostStatus              = $postStatus
+    PostHttpStatus          = $postHttpStatus
+  }
+
+  Write-Log -Level INFO -Message "Runbook completed. Assignments=$($assignmentResults.Count), Definitions=$($definitionResults.Count), PolicySets=$($policySetResults.Count), Failed=$failedDefinitionCount, PostStatus=$postStatus, Duration=$($durationSec)s."
+
+  return $summary
+}
+
+# ============================================================================
+# SCRIPT EXECUTION
+# ============================================================================
+
+# Allow test frameworks to source functions without executing the runbook
+if ($env:AZLH_SKIP_POLICY_RUN -eq '1') {
+  Write-Verbose 'Skipping runbook execution because AZLH_SKIP_POLICY_RUN=1.'
+  return
+}
+
+# Execute main function with all provided parameters
+Invoke-AzurePolicyInventory `
+  -UmiClientId $UmiClientId `
+  -SubscriptionId $SubscriptionId `
+  -WorkspaceName $WorkspaceName `
+  -LogicAppUri $LogicAppUri `
+  -IncludePolicyRule:$IncludePolicyRule `
+  -VerboseLogging:$VerboseLogging

--- a/automation/Get-AzurePolicies.ps1
+++ b/automation/Get-AzurePolicies.ps1
@@ -770,7 +770,7 @@ function Invoke-AzurePolicyInventory {
       if ($_.Exception -and $_.Exception.PSObject.Properties['Response']) {
         try { $postHttpStatus = [int]$_.Exception.Response.StatusCode } catch { $postHttpStatus = $null }
       }
-      Write-Log -Level ERROR -Message "Logic App POST failed (httpStatus=$postHttpStatus): $($_.Exception.Message)"
+      Write-Log -Level ERROR -Message "Logic App POST failed (httpStatus=$postHttpStatus). Check Logic App URI and SAS token validity."
     }
   }
   else {

--- a/automation/Get-SentinelPricing.ps1
+++ b/automation/Get-SentinelPricing.ps1
@@ -1,0 +1,665 @@
+#Requires -Version 7.0
+
+<#
+Disclaimer: This script is provided "as-is" without warranty of any kind.
+
+This script was not developed or tested by the repo owner. It was contributed by a community member and is provided for reference and educational purposes. Please review and test the script in a non-production environment before using it in production.
+
+I do not have the code for the logic app that this runbook posts to, but the general idea is:
+- This runbook is triggered on a schedule (e.g., daily) in Azure Automation.
+- It retrieves the pricing tier of a Microsoft Sentinel / Log Analytics workspace.
+- It posts this information to a Logic App endpoint, which can then log it, send notifications, or take other actions based on the pricing tier.
+
+
+.SYNOPSIS
+Retrieves the Microsoft Sentinel / Log Analytics workspace pricing tier and posts it to a Logic App endpoint.
+
+.DESCRIPTION
+This runbook:
+- Resolves all inputs from parameters first, then environment variables, then Automation variables.
+- Validates all required inputs before any Azure call.
+- Authenticates to Azure using a user-assigned managed identity (UAMI) clientId.
+- Reads the Log Analytics workspace SKU and maps it to a human-friendly pricing tier.
+- Posts a JSON payload to a Logic App endpoint with retry and backoff.
+- Emits a structured summary object for downstream automation and auditing.
+
+Automation variable names used when parameters are omitted:
+- UMI_ID (or UMI_CLIENT_ID)
+- SUBSCRIPTION_ID
+- WORKSPACE_NAME
+- RESOURCE_GROUP_NAME
+- PRICINGTIER_API
+
+UAMI role requirements (minimum):
+- Reader at subscription scope (covers workspace read operations)
+
+.PARAMETER umiClientId
+User-assigned managed identity (UAMI) clientId (GUID). Alias: UMIId.
+
+.PARAMETER subscriptionId
+Azure subscription ID (GUID).
+
+.PARAMETER workspaceName
+Log Analytics workspace name.
+
+.PARAMETER resourceGroupName
+Resource group name where the workspace exists. Alias: resourceGroup.
+
+.PARAMETER pricingTierApi
+Logic App HTTP endpoint URI (HTTPS with SAS token) to post the pricing tier payload.
+
+.PARAMETER VerboseLogging
+When specified, enables verbose-level log output for troubleshooting.
+
+.EXAMPLE
+.\Get-SentinelPricing.ps1 `
+  -umiClientId '11111111-1111-1111-1111-111111111111' `
+  -subscriptionId '22222222-2222-2222-2222-222222222222' `
+  -workspaceName 'law-sentinel-eastus' `
+  -resourceGroupName 'rg-sentinel-prod' `
+  -pricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/.../triggers/manual/paths/invoke?...&sig=...'
+
+Retrieves the pricing tier for the specified workspace and posts it to the Logic App.
+
+.NOTES
+Logic App URI handling: The URI is treated as a secret (SAS token in query string).
+Only the host portion is ever logged. The full URI never appears in output, warning,
+or verbose streams.
+
+-WhatIf skips only the Logic App POST. Authentication, context-setting, and workspace
+lookup still execute so you can verify wiring without sending data.
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param (
+  [Parameter()]
+  [Alias('UMIId')]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $umiClientId,
+
+  [Parameter()]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $subscriptionId,
+
+  [Parameter()]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $workspaceName,
+
+  [Parameter()]
+  [Alias('resourceGroup')]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $resourceGroupName,
+
+  [Parameter()]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $pricingTierApi,
+
+  [Parameter()]
+  [switch]
+  $VerboseLogging
+)
+
+# ============================================================================
+# SCRIPT INITIALIZATION
+# ============================================================================
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$script:RunbookVersion = '1.1.0'
+
+# ============================================================================
+# HELPER FUNCTIONS
+# ============================================================================
+
+<#
+.SYNOPSIS
+Safely retrieves an Azure Automation variable without throwing if unavailable.
+
+.PARAMETER Name
+The name of the Automation variable to retrieve.
+#>
+function Get-AutomationVariableSafe {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Name
+  )
+
+  $command = Get-Command -Name 'Get-AutomationVariable' -ErrorAction SilentlyContinue
+  if (-not $command) {
+    return $null
+  }
+
+  try {
+    return Get-AutomationVariable -Name $Name
+  }
+  catch {
+    Write-Verbose "Failed to read Automation variable '$Name': $($_.Exception.Message)"
+    return $null
+  }
+}
+
+<#
+.SYNOPSIS
+Resolves a configuration value from multiple sources in priority order.
+
+.DESCRIPTION
+Cascading resolution: parameter > environment variable > Automation variable.
+
+.PARAMETER parameterValue
+The value passed as a script parameter.
+
+.PARAMETER environmentVariableNames
+Array of environment/Automation variable names to check in order.
+
+.PARAMETER parameterName
+Friendly parameter name for error messages.
+#>
+function Resolve-ConfiguredValue {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [AllowNull()]
+    [string]
+    $parameterValue,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string[]]
+    $environmentVariableNames,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $parameterName
+  )
+
+  if (-not [string]::IsNullOrWhiteSpace($parameterValue)) {
+    return $parameterValue.Trim()
+  }
+
+  foreach ($envName in $environmentVariableNames) {
+    $envValue = [Environment]::GetEnvironmentVariable($envName)
+    if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+      return $envValue.Trim()
+    }
+  }
+
+  foreach ($autoName in $environmentVariableNames) {
+    $autoValue = Get-AutomationVariableSafe -Name $autoName
+    if (-not [string]::IsNullOrWhiteSpace($autoValue)) {
+      return ([string]$autoValue).Trim()
+    }
+  }
+
+  throw "Missing required value '$parameterName'. Provide parameter '$parameterName' or set one of: $($environmentVariableNames -join ', ')."
+}
+
+<#
+.SYNOPSIS
+Validates that a string is a properly formatted GUID.
+
+.PARAMETER value
+The string to validate.
+
+.PARAMETER parameterName
+Friendly parameter name for error messages.
+#>
+function Assert-ValidGuid {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $value,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $parameterName
+  )
+
+  $trimmed = $value.Trim()
+  if ($trimmed -notmatch '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
+    throw "$parameterName must be a valid GUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)."
+  }
+}
+
+<#
+.SYNOPSIS
+Validates that a URI is an absolute HTTPS URI.
+
+.PARAMETER uri
+The URI string to validate.
+
+.PARAMETER parameterName
+Friendly parameter name for error messages.
+#>
+function Test-IsHttpsUri {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $uri,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $parameterName
+  )
+
+  try {
+    $parsed = [Uri]::new($uri)
+  }
+  catch {
+    throw "$parameterName is not a valid URI."
+  }
+
+  if (-not $parsed.IsAbsoluteUri) {
+    throw "$parameterName must be an absolute URI."
+  }
+
+  if ($parsed.Scheme -ne 'https') {
+    throw "$parameterName must use HTTPS scheme. Received scheme: '$($parsed.Scheme)'."
+  }
+}
+
+<#
+.SYNOPSIS
+Extracts only the host portion of a URI for safe logging.
+
+.DESCRIPTION
+Logic App URIs contain SAS tokens in the query string. This function returns
+only the host so the full URI (including secrets) is never logged.
+
+.PARAMETER uri
+The full URI string.
+#>
+function Get-UriHostForLog {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $uri
+  )
+
+  try {
+    return ([Uri]::new($uri)).Host
+  }
+  catch {
+    return '(invalid-uri)'
+  }
+}
+
+<#
+.SYNOPSIS
+Masks a string for safe logging, showing only the last 4 characters.
+
+.PARAMETER value
+The string to mask.
+#>
+function Get-MaskedValue {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $value
+  )
+
+  if ($value.Length -le 4) {
+    return '****'
+  }
+  return "$('*' * ($value.Length - 4))$($value.Substring($value.Length - 4))"
+}
+
+<#
+.SYNOPSIS
+Writes a structured log message with RunId, timestamp, and severity level.
+
+.PARAMETER Level
+Log level: INFO, WARN, ERROR, VERBOSE.
+
+.PARAMETER Message
+The message to log.
+#>
+function Write-Log {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('INFO', 'WARN', 'ERROR', 'VERBOSE')]
+    [string]
+    $Level,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Message
+  )
+
+  $timestamp = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
+  $formatted = "[$timestamp] [$Level] [RunId=$($script:RunId)] $Message"
+
+  switch ($Level) {
+    'INFO'    { Write-Information $formatted -InformationAction Continue }
+    'WARN'    { Write-Warning $formatted }
+    'ERROR'   { Write-Error $formatted -ErrorAction Continue }
+    'VERBOSE' {
+      if ($script:EnableVerboseLogging) {
+        Write-Information $formatted -InformationAction Continue
+      }
+      else {
+        Write-Verbose $formatted
+      }
+    }
+  }
+}
+
+<#
+.SYNOPSIS
+StrictMode-safe property access for objects with varying shapes.
+
+.PARAMETER inputObject
+The object to read from.
+
+.PARAMETER propertyName
+The property name to read.
+#>
+function Get-OptionalPropertyValue {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [AllowNull()]
+    [object]
+    $inputObject,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $propertyName
+  )
+
+  if ($null -eq $inputObject) {
+    return $null
+  }
+
+  $prop = $inputObject.PSObject.Properties[$propertyName]
+  if ($null -eq $prop) {
+    return $null
+  }
+
+  return $prop.Value
+}
+
+<#
+.SYNOPSIS
+Posts a JSON body to a URI with retry logic for transient failures.
+
+.PARAMETER uri
+The target URI.
+
+.PARAMETER body
+The JSON body string.
+
+.PARAMETER logicAppHost
+Host-only string for safe logging (to avoid logging SAS tokens).
+
+.PARAMETER maxAttempts
+Maximum retry attempts.
+
+.PARAMETER timeoutSec
+HTTP timeout in seconds.
+#>
+function Invoke-RestMethodWithRetry {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $uri,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $body,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $logicAppHost,
+
+    [Parameter()]
+    [ValidateRange(1, 10)]
+    [int]
+    $maxAttempts = 5,
+
+    [Parameter()]
+    [ValidateRange(1, 300)]
+    [int]
+    $timeoutSec = 60
+  )
+
+  for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+    try {
+      Write-Log -Level VERBOSE -Message "POST to $logicAppHost (attempt $attempt/$maxAttempts)"
+      return Invoke-RestMethod -Method Post -Uri $uri -Body $body -ContentType 'application/json' -TimeoutSec $timeoutSec
+    }
+    catch {
+      $ex = $_.Exception
+      $statusCode = $null
+      $retryAfterSec = $null
+
+      if ($ex.PSObject.Properties.Name -contains 'Response' -and $null -ne $ex.Response) {
+        try { $statusCode = [int]$ex.Response.StatusCode } catch { $statusCode = $null }
+        try {
+          $retryAfterHeader = $ex.Response.Headers['Retry-After']
+          if (-not [string]::IsNullOrWhiteSpace($retryAfterHeader)) {
+            $retryAfterSec = [int]$retryAfterHeader
+          }
+        }
+        catch { $retryAfterSec = $null }
+      }
+
+      $isTransient = ($statusCode -eq 429 -or ($statusCode -ge 500 -and $statusCode -le 599) -or $null -eq $statusCode)
+      if (-not $isTransient -or $attempt -ge $maxAttempts) {
+        throw
+      }
+
+      $baseDelay = [Math]::Min(2 * $attempt, 10)
+      $delaySec = if ($null -ne $retryAfterSec -and $retryAfterSec -ge 1) { $retryAfterSec } else { $baseDelay }
+      Write-Log -Level WARN -Message "POST to $logicAppHost failed (statusCode=$statusCode, attempt $attempt/$maxAttempts). Retrying in $($delaySec)s."
+      Start-Sleep -Seconds $delaySec
+    }
+  }
+}
+
+# ============================================================================
+# MAIN FUNCTION
+# ============================================================================
+
+<#
+.SYNOPSIS
+Core orchestration function for retrieving workspace pricing tier and posting to Logic App.
+
+.DESCRIPTION
+Performs the complete workflow:
+1. Resolves all configuration from parameters, environment, or Automation variables
+2. Validates all inputs
+3. Authenticates with user-assigned managed identity
+4. Reads workspace SKU and maps to human-friendly pricing tier
+5. Posts pricing payload to Logic App endpoint
+6. Returns structured summary object
+
+-WhatIf skips only the Logic App POST. Auth and workspace lookup still execute.
+#>
+function Invoke-SentinelPricingCheck {
+  [CmdletBinding(SupportsShouldProcess = $true)]
+  param(
+    [Parameter()] [string] $UmiClientId,
+    [Parameter()] [string] $SubscriptionId,
+    [Parameter()] [string] $WorkspaceName,
+    [Parameter()] [string] $ResourceGroupName,
+    [Parameter()] [string] $PricingTierApi,
+    [Parameter()] [switch] $VerboseLogging
+  )
+
+  $script:RunId = [Guid]::NewGuid().ToString()
+  $script:EnableVerboseLogging = $VerboseLogging.IsPresent -or $env:AZLH_VERBOSE_LOGGING -eq '1'
+  $runStartUtc = [DateTime]::UtcNow
+
+  Write-Log -Level INFO -Message "Starting Sentinel pricing check (version $($script:RunbookVersion))."
+
+  # -------------------------------------------------------------------
+  # STEP 1: Resolve configuration
+  # -------------------------------------------------------------------
+
+  $resolvedUmiClientId = Resolve-ConfiguredValue -parameterValue $UmiClientId -environmentVariableNames @('UMI_ID', 'UMI_CLIENT_ID') -parameterName 'umiClientId'
+  $resolvedSubscriptionId = Resolve-ConfiguredValue -parameterValue $SubscriptionId -environmentVariableNames @('SUBSCRIPTION_ID') -parameterName 'subscriptionId'
+  $resolvedWorkspaceName = Resolve-ConfiguredValue -parameterValue $WorkspaceName -environmentVariableNames @('WORKSPACE_NAME') -parameterName 'workspaceName'
+  $resolvedResourceGroupName = Resolve-ConfiguredValue -parameterValue $ResourceGroupName -environmentVariableNames @('RESOURCE_GROUP_NAME') -parameterName 'resourceGroupName'
+  $resolvedPricingTierApi = Resolve-ConfiguredValue -parameterValue $PricingTierApi -environmentVariableNames @('PRICINGTIER_API') -parameterName 'pricingTierApi'
+
+  # -------------------------------------------------------------------
+  # STEP 2: Validate inputs
+  # -------------------------------------------------------------------
+
+  Assert-ValidGuid -value $resolvedUmiClientId -parameterName 'umiClientId'
+  Assert-ValidGuid -value $resolvedSubscriptionId -parameterName 'subscriptionId'
+  Test-IsHttpsUri -uri $resolvedPricingTierApi -parameterName 'pricingTierApi'
+
+  $logicAppHost = Get-UriHostForLog -uri $resolvedPricingTierApi
+  Write-Log -Level INFO -Message "Configuration validated. Subscription=$(Get-MaskedValue $resolvedSubscriptionId), UMI=$(Get-MaskedValue $resolvedUmiClientId), Workspace=$resolvedWorkspaceName, RG=$resolvedResourceGroupName, LogicAppHost=$logicAppHost"
+
+  # -------------------------------------------------------------------
+  # STEP 3: Authenticate
+  # -------------------------------------------------------------------
+
+  Write-Log -Level INFO -Message 'Authenticating to Azure (managed identity).'
+  Connect-AzAccount -Identity -AccountId $resolvedUmiClientId -ErrorAction Stop | Out-Null
+  Set-AzContext -SubscriptionId $resolvedSubscriptionId -ErrorAction Stop | Out-Null
+
+  # -------------------------------------------------------------------
+  # STEP 4: Retrieve workspace and resolve pricing tier
+  # -------------------------------------------------------------------
+
+  Write-Log -Level INFO -Message "Retrieving Log Analytics workspace '$resolvedWorkspaceName' in resource group '$resolvedResourceGroupName'."
+  $workspace = Get-AzOperationalInsightsWorkspace -ResourceGroupName $resolvedResourceGroupName -Name $resolvedWorkspaceName -ErrorAction Stop
+
+  $skuName = $null
+  $sku = Get-OptionalPropertyValue -inputObject $workspace -propertyName 'Sku'
+  if ($null -ne $sku) {
+    $skuName = Get-OptionalPropertyValue -inputObject $sku -propertyName 'Name'
+  }
+  if ([string]::IsNullOrWhiteSpace($skuName)) {
+    $skuName = [string]$sku
+  }
+
+  switch ($skuName) {
+    'PerGB2018' {
+      $priceTier = 'Pay-As-You-Go'
+    }
+    'CapacityReservation' {
+      $capacity = Get-OptionalPropertyValue -inputObject $sku -propertyName 'CapacityReservationLevel'
+      if ($null -eq $capacity) {
+        $capacity = Get-OptionalPropertyValue -inputObject $workspace -propertyName 'CapacityReservationLevel'
+      }
+      $priceTier = if ($null -ne $capacity) { "$capacity GB" } else { 'Commitment Tier' }
+    }
+    default {
+      $priceTier = "Unknown ($skuName)"
+    }
+  }
+
+  Write-Log -Level INFO -Message "Resolved pricing tier: $priceTier (SKU: $skuName)."
+
+  # -------------------------------------------------------------------
+  # STEP 5: Build and POST payload
+  # -------------------------------------------------------------------
+
+  $jsonBody = @{
+    PricingTier            = $priceTier
+    WorkspaceName          = $workspace.Name
+    WorkspaceResourceGroup = $resolvedResourceGroupName
+    SubscriptionId         = $resolvedSubscriptionId
+    SkuName                = $skuName
+  } | ConvertTo-Json -Depth 5
+
+  $postStatus = 'NotAttempted'
+  $postHttpStatus = $null
+
+  if ($PSCmdlet.ShouldProcess($logicAppHost, 'Post Sentinel pricing tier')) {
+    try {
+      Write-Log -Level INFO -Message "Posting pricing tier to Logic App host: $logicAppHost"
+      Invoke-RestMethodWithRetry -uri $resolvedPricingTierApi -body $jsonBody -logicAppHost $logicAppHost | Out-Null
+      $postStatus = 'Success'
+      Write-Log -Level INFO -Message 'Logic App POST succeeded.'
+    }
+    catch {
+      $postStatus = 'Failed'
+      if ($_.Exception -and $_.Exception.PSObject.Properties['Response']) {
+        try { $postHttpStatus = [int]$_.Exception.Response.StatusCode } catch { $postHttpStatus = $null }
+      }
+      Write-Log -Level ERROR -Message "Logic App POST failed (httpStatus=$postHttpStatus). Check Logic App URI and SAS token validity."
+    }
+  }
+  else {
+    $postStatus = 'Skipped (WhatIf)'
+    Write-Log -Level INFO -Message 'Logic App POST skipped (-WhatIf).'
+  }
+
+  # -------------------------------------------------------------------
+  # STEP 6: Emit structured summary
+  # -------------------------------------------------------------------
+
+  $runEndUtc = [DateTime]::UtcNow
+  $durationSec = [Math]::Round(($runEndUtc - $runStartUtc).TotalSeconds, 2)
+
+  $summary = [PSCustomObject]@{
+    RunId              = $script:RunId
+    RunbookVersion     = $script:RunbookVersion
+    StartTimeUtc       = $runStartUtc.ToString('o')
+    EndTimeUtc         = $runEndUtc.ToString('o')
+    DurationSeconds    = $durationSec
+    WorkspaceName      = $workspace.Name
+    PricingTier        = $priceTier
+    SkuName            = $skuName
+    SubscriptionId     = $resolvedSubscriptionId
+    ResourceGroupName  = $resolvedResourceGroupName
+    LogicAppHost       = $logicAppHost
+    PostStatus         = $postStatus
+    PostHttpStatus     = $postHttpStatus
+  }
+
+  Write-Log -Level INFO -Message "Runbook completed. PricingTier=$priceTier, SKU=$skuName, PostStatus=$postStatus, Duration=$($durationSec)s."
+
+  return $summary
+}
+
+# ============================================================================
+# SCRIPT EXECUTION
+# ============================================================================
+
+# Allow test frameworks to source functions without executing the runbook
+if ($env:AZLH_SKIP_PRICING_RUN -eq '1') {
+  Write-Verbose 'Skipping runbook execution because AZLH_SKIP_PRICING_RUN=1.'
+  return
+}
+
+# Execute main function with all provided parameters
+Invoke-SentinelPricingCheck `
+  -UmiClientId $umiClientId `
+  -SubscriptionId $subscriptionId `
+  -WorkspaceName $workspaceName `
+  -ResourceGroupName $resourceGroupName `
+  -PricingTierApi $pricingTierApi `
+  -VerboseLogging:$VerboseLogging

--- a/automation/README.md
+++ b/automation/README.md
@@ -404,9 +404,10 @@ Get-AzAutomationJobOutput -ResourceGroupName "SOC-Automation-RG" `
 
 1. **Limit RBAC Permissions** - Grant minimum required roles to UAMI
 2. **Secure Logic App Endpoints** - Use SAS tokens with expiration dates
-3. **Enable Diagnostic Logging** - Monitor all automation account activities
-4. **Review Job Outputs** - Regularly audit runbook execution logs
-5. **Use Private Endpoints** - Consider private connectivity for sensitive environments
+3. **Protect Logic App URIs at runtime** - Logic App webhook URIs contain SAS tokens in the query string and are bearer secrets. The `POLICYMONITORING_API` and `PRICINGTIER_API` Automation variables store these URIs (the policy variable is encrypted at rest). At runtime, the `Get-AzurePolicies` and `Get-SentinelPricing` runbooks use `Get-UriHostForLog` to log only the host portion — the full URI (including SAS token) never appears in job output, warning, verbose, or error streams.
+4. **Enable Diagnostic Logging** - Monitor all automation account activities
+5. **Review Job Outputs** - Regularly audit runbook execution logs
+6. **Use Private Endpoints** - Consider private connectivity for sensitive environments
 
 ## Support & Documentation
 

--- a/automation/README.md
+++ b/automation/README.md
@@ -147,6 +147,7 @@ Navigate to: **Automation Account → Shared Resources → Variables**
 | `SEARCH_END_TIME_UTC`   | String | ISO 8601 datetime (UTC)        | `Invoke-AzSentinelSearchJob`            | End of search time range                     |
 | `SEARCH_RETENTION_DAYS` | Int    | Number of days (e.g. `14`)     | `Invoke-AzSentinelSearchJob` (optional) | Retention period for search result table     |
 | `SEARCH_LIMIT`          | Int    | Row limit (e.g. `100000`)      | `Invoke-AzSentinelSearchJob` (optional) | Maximum rows returned by search job          |
+| `POLICYMONITORING_API`  | String | Logic App endpoint (encrypted) | `Get-AzurePolicies`                     | Logic App URI for policy inventory updates   |
 
 ### 2. Verify Deployment
 
@@ -264,6 +265,58 @@ Invoke-AzSentinelSearchJob.ps1 `
   -EndSearchTime "2026-02-21T00:00:00Z" `
   -RetentionInDays 14 `
   -Limit 100000
+```
+
+### Get-AzurePolicies
+
+**Purpose:** Collects Azure Policy assignments and definitions for a subscription and posts the inventory to a Logic App endpoint for MSSP visibility.
+
+**Production behavior:**
+
+- Resolves inputs from runbook parameters first, then environment variables, then Automation variables
+- Validates all required inputs (GUIDs, HTTPS URI) before any Azure API call
+- Authenticates with **user-assigned managed identity only** (`Connect-AzAccount -Identity -AccountId <UAMI ClientId>`)
+- Enumerates policy assignments at subscription scope
+- Resolves both policy definitions and policy set definitions (initiatives)
+- Posts a slim JSON inventory payload to a Logic App endpoint with retry and backoff
+- Emits a structured summary object for downstream automation and auditing
+- Supports `-WhatIf` to preview without posting
+- Never logs the full Logic App URI (SAS-protected webhook); only the host is logged
+
+**Parameters and fallback variables:**
+
+| Parameter          | Variable Fallback           | Required |
+| ------------------ | --------------------------- | -------- |
+| `UmiClientId`      | `UMI_ID` or `UMI_CLIENT_ID` | Yes      |
+| `SubscriptionId`   | `SUBSCRIPTION_ID`           | Yes      |
+| `WorkspaceName`    | `WORKSPACE_NAME`            | Yes      |
+| `LogicAppUri`      | `POLICYMONITORING_API`      | Yes      |
+| `IncludePolicyRule` | —                          | No       |
+| `VerboseLogging`   | `AZLH_VERBOSE_LOGGING`      | No       |
+
+**UAMI role requirements (minimum):**
+
+- `Reader` at subscription scope (covers `Microsoft.Authorization/policyAssignments/read`, `policyDefinitions/read`, and `policySetDefinitions/read`)
+
+**Example runbook execution:**
+
+```powershell
+.\Get-AzurePolicies.ps1 `
+  -UmiClientId 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' `
+  -SubscriptionId 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' `
+  -WorkspaceName 'law-sentinel-eastus' `
+  -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/.../triggers/manual/paths/invoke?...&sig=...'
+```
+
+**With full policy rules:**
+
+```powershell
+.\Get-AzurePolicies.ps1 `
+  -UmiClientId 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' `
+  -SubscriptionId 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' `
+  -WorkspaceName 'law-sentinel-eastus' `
+  -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/...' `
+  -IncludePolicyRule
 ```
 
 ## Troubleshooting

--- a/automation/README.md
+++ b/automation/README.md
@@ -285,14 +285,14 @@ Invoke-AzSentinelSearchJob.ps1 `
 
 **Parameters and fallback variables:**
 
-| Parameter          | Variable Fallback           | Required |
-| ------------------ | --------------------------- | -------- |
-| `UmiClientId`      | `UMI_ID` or `UMI_CLIENT_ID` | Yes      |
-| `SubscriptionId`   | `SUBSCRIPTION_ID`           | Yes      |
-| `WorkspaceName`    | `WORKSPACE_NAME`            | Yes      |
-| `LogicAppUri`      | `POLICYMONITORING_API`      | Yes      |
-| `IncludePolicyRule` | —                          | No       |
-| `VerboseLogging`   | `AZLH_VERBOSE_LOGGING`      | No       |
+| Parameter                              | Variable Fallback           | Required |
+| -------------------------------------- | --------------------------- | -------- |
+| `LogicAppUri` (alias: `policyMonitoringApi`) | `POLICYMONITORING_API` | Yes      |
+| `UmiClientId` (alias: `UMIId`)         | `UMI_ID` or `UMI_CLIENT_ID` | Yes      |
+| `SubscriptionId`                       | `SUBSCRIPTION_ID`           | Yes      |
+| `WorkspaceName`                        | `WORKSPACE_NAME`            | Yes      |
+| `IncludePolicyRule`                    | —                           | No       |
+| `VerboseLogging`                       | `AZLH_VERBOSE_LOGGING`      | No       |
 
 **UAMI role requirements (minimum):**
 

--- a/automation/automationAccount.json
+++ b/automation/automationAccount.json
@@ -68,6 +68,27 @@
       },
       "defaultValue": "Invoke-AzSentinelSearchJob"
     },
+    "policyRunbookContentUri": {
+      "type": "string",
+      "metadata": {
+        "description": "URL for the Azure Policy inventory runbook content"
+      },
+      "defaultValue": "https://raw.githubusercontent.com/joelst/AzLighthouse/refs/heads/main/automation/Get-AzurePolicies.ps1"
+    },
+    "policyRunbookName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Azure Policy inventory runbook"
+      },
+      "defaultValue": "Get-AzurePolicies"
+    },
+    "policyMonitoringLogicAppUri": {
+      "type": "secureString",
+      "metadata": {
+        "description": "Logic App URI for policy monitoring inventory updates (HTTPS with SAS token)"
+      },
+      "defaultValue": "https://logicapp.azure.com/"
+    },
     "userAssignedIdentityName": {
       "type": "string",
       "metadata": {
@@ -147,6 +168,7 @@
     "dataConnectorRunbookDescription": "Runbook to report the data connector status for Sentinel",
     "pricingRunbookDescription": "Runbook to retrieve pricing tier information for Sentinel",
     "searchJobRunbookDescription": "Runbook to create Sentinel search jobs in Log Analytics",
+    "policyRunbookDescription": "Runbook to collect Azure Policy assignments and definitions inventory",
     "sentinelWorkspaceResourceId": "[if(startsWith(parameters('sentinelWorkspaceName'), '/subscriptions/'), parameters('sentinelWorkspaceName'), resourceId('Microsoft.OperationalInsights/workspaces', parameters('sentinelWorkspaceName')))]"
   },
   "resources": [
@@ -261,9 +283,29 @@
       ]
     },
     {
-      "type": "Microsoft.Automation/automationAccounts/runtimeEnvironments/packages",
+      "type": "Microsoft.Automation/automationAccounts/runbooks",
       "apiVersion": "2024-10-23",
-      "name": "[format('{0}/{1}/Az.Accounts', parameters('automationAccountName'), variables('pwshRuntimeName'))]",
+      "name": "[format('{0}/{1}', parameters('automationAccountName'), parameters('policyRunbookName'))]",
+      "location": "[resourceGroup().location]",
+      "tags": {},
+      "properties": {
+        "runbookType": "PowerShell",
+        "runtimeEnvironment": "[variables('pwshRuntimeName')]",
+        "logProgress": false,
+        "logVerbose": false,
+        "description": "[variables('policyRunbookDescription')]",
+        "publishContentLink": {
+          "uri": "[parameters('policyRunbookContentUri')]",
+          "version": "1.0.0.0"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]",
+        "[resourceId('Microsoft.Automation/automationAccounts/runtimeEnvironments', parameters('automationAccountName'), variables('pwshRuntimeName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Automation/automationAccounts/runtimeEnvironments/packages",
       "properties": {
         "contentLink": {
           "uri": "https://www.powershellgallery.com/api/v2/package/Az.Accounts/5.3.4"
@@ -472,9 +514,25 @@
       }
     },
     {
-      "type": "Microsoft.Automation/automationAccounts/variables",
+      "type": "Microsoft.Automation/automationAccounts/jobSchedules",
       "apiVersion": "2023-11-01",
-      "name": "[concat(parameters('automationAccountName'), '/APP_REG_NAME')]",
+      "name": "[format('{0}/{1}', parameters('automationAccountName'), guid(parameters('newGuid'), parameters('policyRunbookName')))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]",
+        "[resourceId('Microsoft.Automation/automationAccounts/runbooks', parameters('automationAccountName'), parameters('policyRunbookName'))]",
+        "[resourceId('Microsoft.Automation/automationAccounts/schedules', parameters('automationAccountName'), variables('runbookScheduleName'))]"
+      ],
+      "properties": {
+        "runbook": {
+          "name": "[parameters('policyRunbookName')]"
+        },
+        "schedule": {
+          "name": "[variables('runbookScheduleName')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Automation/automationAccounts/variables",
       "properties": {
         "isEncrypted": false,
         "value": "[concat('\"', parameters('servicePrincipalCredentialAppReg'), '\"')]",
@@ -570,6 +628,19 @@
         "isEncrypted": false,
         "value": "[concat('\"', parameters('PricingTierLogicAppUri'), '\"')]",
         "description": "URI for the pricing tier API used for cost estimation of new service principals"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Automation/automationAccounts/variables",
+      "apiVersion": "2023-11-01",
+      "name": "[concat(parameters('automationAccountName'), '/POLICYMONITORING_API')]",
+      "properties": {
+        "isEncrypted": true,
+        "value": "[concat('\"', parameters('policyMonitoringLogicAppUri'), '\"')]",
+        "description": "Logic App URI for Azure Policy inventory monitoring (encrypted)"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Automation/automationAccounts', parameters('automationAccountName'))]"

--- a/automation/automationAccount.json
+++ b/automation/automationAccount.json
@@ -306,6 +306,8 @@
     },
     {
       "type": "Microsoft.Automation/automationAccounts/runtimeEnvironments/packages",
+      "apiVersion": "2024-10-23",
+      "name": "[format('{0}/{1}/Az.Accounts', parameters('automationAccountName'), variables('pwshRuntimeName'))]",
       "properties": {
         "contentLink": {
           "uri": "https://www.powershellgallery.com/api/v2/package/Az.Accounts/5.3.4"
@@ -533,6 +535,8 @@
     },
     {
       "type": "Microsoft.Automation/automationAccounts/variables",
+      "apiVersion": "2023-11-01",
+      "name": "[concat(parameters('automationAccountName'), '/APP_REG_NAME')]",
       "properties": {
         "isEncrypted": false,
         "value": "[concat('\"', parameters('servicePrincipalCredentialAppReg'), '\"')]",

--- a/automation/tests/Get-AzurePolicies.Tests.ps1
+++ b/automation/tests/Get-AzurePolicies.Tests.ps1
@@ -1,0 +1,414 @@
+# Pester tests for Get-AzurePolicies runbook
+# Requires: Pester 5+
+# Run with: Invoke-Pester -Path .\Get-AzurePolicies.Tests.ps1
+
+BeforeAll {
+  $env:AZLH_SKIP_POLICY_RUN = '1'
+  . "$PSScriptRoot\..\Get-AzurePolicies.ps1"
+}
+
+AfterAll {
+  Remove-Item Env:AZLH_SKIP_POLICY_RUN -ErrorAction SilentlyContinue
+}
+
+# ============================================================================
+# HELPER FUNCTION TESTS
+# ============================================================================
+
+Describe 'Assert-ValidGuid' {
+  It 'Accepts a valid GUID' {
+    { Assert-ValidGuid -value '11111111-1111-1111-1111-111111111111' -parameterName 'TestParam' } | Should -Not -Throw
+  }
+
+  It 'Rejects an invalid GUID' {
+    { Assert-ValidGuid -value 'not-a-guid' -parameterName 'TestParam' } | Should -Throw '*valid GUID*'
+  }
+
+  It 'Rejects an empty string via ValidateNotNullOrEmpty' {
+    { Assert-ValidGuid -value '' -parameterName 'TestParam' } | Should -Throw
+  }
+}
+
+Describe 'Test-IsHttpsUri' {
+  It 'Accepts HTTPS URI' {
+    { Test-IsHttpsUri -uri 'https://example.com/path' -parameterName 'TestUri' } | Should -Not -Throw
+  }
+
+  It 'Rejects HTTP URI' {
+    { Test-IsHttpsUri -uri 'http://example.com/path' -parameterName 'TestUri' } | Should -Throw '*HTTPS*'
+  }
+
+  It 'Rejects invalid URI' {
+    { Test-IsHttpsUri -uri 'not a uri at all' -parameterName 'TestUri' } | Should -Throw '*valid URI*'
+  }
+}
+
+Describe 'Get-UriHostForLog' {
+  It 'Returns host portion only' {
+    $result = Get-UriHostForLog -uri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+    $result | Should -Be 'prod-00.eastus.logic.azure.com'
+  }
+
+  It 'Returns placeholder for invalid URI' {
+    $result = Get-UriHostForLog -uri 'not-a-uri'
+    $result | Should -Be '(invalid-uri)'
+  }
+}
+
+Describe 'Get-MaskedValue' {
+  It 'Masks all but last 4 characters' {
+    $result = Get-MaskedValue -value '11111111-1111-1111-1111-111111111111'
+    $result | Should -Match '\*+1111$'
+    $result | Should -Not -Be '11111111-1111-1111-1111-111111111111'
+  }
+
+  It 'Returns all stars for short values' {
+    $result = Get-MaskedValue -value 'abc'
+    $result | Should -Be '****'
+  }
+}
+
+Describe 'Resolve-ConfiguredValue' {
+  It 'Uses parameter value before environment variable' {
+    $env:POLICYMONITORING_API = 'FromEnvironment'
+    try {
+      $result = Resolve-ConfiguredValue -parameterValue 'FromParameter' -environmentVariableNames @('POLICYMONITORING_API') -parameterName 'LogicAppUri'
+      $result | Should -Be 'FromParameter'
+    }
+    finally {
+      Remove-Item Env:POLICYMONITORING_API -ErrorAction SilentlyContinue
+    }
+  }
+
+  It 'Uses environment variable when parameter is empty' {
+    $env:POLICYMONITORING_API = 'FromEnvironment'
+    try {
+      $result = Resolve-ConfiguredValue -parameterValue '' -environmentVariableNames @('POLICYMONITORING_API') -parameterName 'LogicAppUri'
+      $result | Should -Be 'FromEnvironment'
+    }
+    finally {
+      Remove-Item Env:POLICYMONITORING_API -ErrorAction SilentlyContinue
+    }
+  }
+
+  It 'Throws when neither parameter nor environment value is present' {
+    Remove-Item Env:POLICYMONITORING_API -ErrorAction SilentlyContinue
+    { Resolve-ConfiguredValue -parameterValue '' -environmentVariableNames @('POLICYMONITORING_API') -parameterName 'LogicAppUri' } | Should -Throw
+  }
+}
+
+Describe 'Get-OptionalPropertyValue' {
+  It 'Returns property value when present' {
+    $obj = [PSCustomObject]@{ Name = 'TestPolicy' }
+    Get-OptionalPropertyValue -inputObject $obj -propertyName 'Name' | Should -Be 'TestPolicy'
+  }
+
+  It 'Returns null when property is missing' {
+    $obj = [PSCustomObject]@{ Name = 'TestPolicy' }
+    Get-OptionalPropertyValue -inputObject $obj -propertyName 'MissingProp' | Should -BeNullOrEmpty
+  }
+
+  It 'Returns null when object is null' {
+    Get-OptionalPropertyValue -inputObject $null -propertyName 'Name' | Should -BeNullOrEmpty
+  }
+}
+
+# ============================================================================
+# MAIN FUNCTION TESTS
+# ============================================================================
+
+Describe 'Invoke-AzurePolicyInventory' {
+  BeforeEach {
+    Mock Connect-AzAccount { }
+    Mock Set-AzContext { }
+    Mock Invoke-RestMethod { }
+
+    Mock Get-AzPolicyAssignment {
+      @(
+        [PSCustomObject]@{
+          Name               = 'audit-vm-extensions'
+          DisplayName        = 'Audit VM Extensions'
+          PolicyDefinitionId = '/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/policyDefinitions/def-1111'
+          EnforcementMode    = 'Default'
+          Scope              = '/subscriptions/22222222-2222-2222-2222-222222222222'
+          Parameters         = @{}
+        },
+        [PSCustomObject]@{
+          Name               = 'cis-benchmark'
+          DisplayName        = 'CIS Benchmark'
+          PolicyDefinitionId = '/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/policySetDefinitions/set-2222'
+          EnforcementMode    = 'Default'
+          Scope              = '/subscriptions/22222222-2222-2222-2222-222222222222'
+          Parameters         = @{}
+        }
+      )
+    }
+
+    Mock Get-AzPolicyDefinition {
+      [PSCustomObject]@{
+        Name                       = 'def-1111'
+        DisplayName                = 'Audit VM Extensions Policy'
+        PolicyType                 = 'Custom'
+        Description                = 'Audits VM extensions'
+        PolicyRule                 = @{ if = @{ field = 'type'; equals = 'Microsoft.Compute/virtualMachines/extensions' }; then = @{ effect = 'audit' } }
+        SystemDataLastModifiedBy   = 'user@contoso.com'
+        SystemDataLastModifiedAt   = '2026-01-15T10:00:00Z'
+      }
+    }
+
+    Mock Get-AzPolicySetDefinition {
+      [PSCustomObject]@{
+        Name                       = 'set-2222'
+        DisplayName                = 'CIS Benchmark Initiative'
+        PolicyType                 = 'Custom'
+        Description                = 'CIS controls'
+        SystemDataLastModifiedBy   = 'admin@contoso.com'
+        SystemDataLastModifiedAt   = '2026-01-20T14:00:00Z'
+      }
+    }
+  }
+
+  It 'Authenticates with UAMI and resolves both definitions and policy sets' {
+    $result = Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+    Should -Invoke Connect-AzAccount -Times 1 -ParameterFilter { $Identity -and $AccountId -eq '11111111-1111-1111-1111-111111111111' }
+    Should -Invoke Set-AzContext -Times 1 -ParameterFilter { $SubscriptionId -eq '22222222-2222-2222-2222-222222222222' }
+    Should -Invoke Get-AzPolicyAssignment -Times 1
+    Should -Invoke Get-AzPolicyDefinition -Times 1
+    Should -Invoke Get-AzPolicySetDefinition -Times 1
+    Should -Invoke Invoke-RestMethod -Times 1
+
+    $result.AssignmentCount | Should -Be 2
+    $result.PolicyDefinitionCount | Should -Be 1
+    $result.PolicySetDefinitionCount | Should -Be 1
+    $result.FailedDefinitionLookups | Should -Be 0
+    $result.PostStatus | Should -Be 'Success'
+    $result.RunId | Should -Not -BeNullOrEmpty
+    $result.RunbookVersion | Should -Not -BeNullOrEmpty
+    $result.DurationSeconds | Should -BeGreaterOrEqual 0
+  }
+
+  It 'Does not include PolicyRule by default' {
+    $script:capturedBody = $null
+    Mock Invoke-RestMethod {
+      param($Method, $Uri, $Body, $ContentType)
+      $script:capturedBody = $Body
+    }
+
+    Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+    $parsed = $script:capturedBody | ConvertFrom-Json
+    $parsed.PolicyDefinitions[0].PSObject.Properties.Name | Should -Not -Contain 'PolicyRule'
+  }
+
+  It 'Includes PolicyRule when -IncludePolicyRule is specified' {
+    $script:capturedBody = $null
+    Mock Invoke-RestMethod {
+      param($Method, $Uri, $Body, $ContentType)
+      $script:capturedBody = $Body
+    }
+
+    Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret' `
+      -IncludePolicyRule
+
+    $parsed = $script:capturedBody | ConvertFrom-Json
+    $parsed.PolicyDefinitions[0].PSObject.Properties.Name | Should -Contain 'PolicyRule'
+  }
+
+  It 'Does not POST when -WhatIf is specified' {
+    $result = Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret' `
+      -WhatIf
+
+    Should -Invoke Invoke-RestMethod -Times 0
+    $result.PostStatus | Should -Be 'Skipped (WhatIf)'
+  }
+
+  It 'Throws on invalid UmiClientId GUID' {
+    { Invoke-AzurePolicyInventory `
+        -UmiClientId 'not-a-guid' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName 'law-prod' `
+        -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+    } | Should -Throw '*valid GUID*'
+  }
+
+  It 'Throws on invalid SubscriptionId GUID' {
+    { Invoke-AzurePolicyInventory `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId 'bad-sub-id' `
+        -WorkspaceName 'law-prod' `
+        -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+    } | Should -Throw '*valid GUID*'
+  }
+
+  It 'Throws on HTTP (non-HTTPS) Logic App URI' {
+    { Invoke-AzurePolicyInventory `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName 'law-prod' `
+        -LogicAppUri 'http://insecure.example.com/workflows/abc'
+    } | Should -Throw '*HTTPS*'
+  }
+
+  It 'Throws on missing required value' {
+    { Invoke-AzurePolicyInventory `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName '' `
+        -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+    } | Should -Throw '*Missing required value*'
+  }
+
+  It 'Captures per-definition failure without aborting the run' {
+    Mock Get-AzPolicyDefinition { throw 'Definition not found' }
+
+    $result = Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+    $result.FailedDefinitionLookups | Should -BeGreaterThan 0
+    $result.PostStatus | Should -Be 'Success'
+  }
+
+  It 'Summary has expected properties' {
+    $result = Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+    $props = $result.PSObject.Properties.Name
+    $props | Should -Contain 'RunId'
+    $props | Should -Contain 'RunbookVersion'
+    $props | Should -Contain 'StartTimeUtc'
+    $props | Should -Contain 'EndTimeUtc'
+    $props | Should -Contain 'DurationSeconds'
+    $props | Should -Contain 'SubscriptionId'
+    $props | Should -Contain 'Scope'
+    $props | Should -Contain 'WorkspaceName'
+    $props | Should -Contain 'AssignmentCount'
+    $props | Should -Contain 'PolicyDefinitionCount'
+    $props | Should -Contain 'PolicySetDefinitionCount'
+    $props | Should -Contain 'FailedDefinitionLookups'
+    $props | Should -Contain 'IncludedPolicyRule'
+    $props | Should -Contain 'LogicAppHost'
+    $props | Should -Contain 'PostStatus'
+    $props | Should -Contain 'PostHttpStatus'
+  }
+
+  It 'Never logs the full Logic App URI' {
+    $logMessages = [System.Collections.Generic.List[string]]::new()
+
+    Mock Write-Information {
+      param($MessageData)
+      $logMessages.Add([string]$MessageData)
+    }
+    Mock Write-Warning {
+      param($Message)
+      $logMessages.Add([string]$Message)
+    }
+    Mock Write-Verbose {
+      param($Message)
+      $logMessages.Add([string]$Message)
+    }
+
+    Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=supersecrettoken123'
+
+    $allOutput = $logMessages -join "`n"
+    $allOutput | Should -Not -Match 'supersecrettoken123'
+    $allOutput | Should -Not -Match 'sig='
+  }
+
+  It 'Handles empty policy assignment list gracefully' {
+    Mock Get-AzPolicyAssignment { @() }
+
+    $result = Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+    $result.AssignmentCount | Should -Be 0
+    $result.PolicyDefinitionCount | Should -Be 0
+    $result.PolicySetDefinitionCount | Should -Be 0
+    $result.PostStatus | Should -Be 'Success'
+  }
+
+  It 'Handles assignment with empty PolicyDefinitionId' {
+    Mock Get-AzPolicyAssignment {
+      @(
+        [PSCustomObject]@{
+          Name               = 'empty-def-assignment'
+          DisplayName        = 'Empty Def'
+          PolicyDefinitionId = ''
+          EnforcementMode    = 'Default'
+          Scope              = '/subscriptions/22222222-2222-2222-2222-222222222222'
+          Parameters         = @{}
+        }
+      )
+    }
+
+    $result = Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+    $result.AssignmentCount | Should -Be 1
+    $result.PolicyDefinitionCount | Should -Be 0
+    Should -Invoke Get-AzPolicyDefinition -Times 0
+  }
+
+  It 'Deduplicates definition lookups for repeated PolicyDefinitionId' {
+    Mock Get-AzPolicyAssignment {
+      @(
+        [PSCustomObject]@{
+          Name               = 'assignment-a'
+          DisplayName        = 'Assignment A'
+          PolicyDefinitionId = '/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/policyDefinitions/same-def'
+          EnforcementMode    = 'Default'
+          Scope              = '/subscriptions/22222222-2222-2222-2222-222222222222'
+          Parameters         = @{}
+        },
+        [PSCustomObject]@{
+          Name               = 'assignment-b'
+          DisplayName        = 'Assignment B'
+          PolicyDefinitionId = '/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Authorization/policyDefinitions/same-def'
+          EnforcementMode    = 'Default'
+          Scope              = '/subscriptions/22222222-2222-2222-2222-222222222222'
+          Parameters         = @{}
+        }
+      )
+    }
+
+    Invoke-AzurePolicyInventory `
+      -UmiClientId '11111111-1111-1111-1111-111111111111' `
+      -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+      -WorkspaceName 'law-prod' `
+      -LogicAppUri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+    Should -Invoke Get-AzPolicyDefinition -Times 1
+  }
+}

--- a/automation/tests/Get-DataConnectorStatus.Tests.ps1
+++ b/automation/tests/Get-DataConnectorStatus.Tests.ps1
@@ -244,7 +244,7 @@ Describe 'Get-LogIngestionMetrics' {
         $result.Id | Should -Be 'ConnectorId'
         $result.Title | Should -Be 'Title'
         $result.Publisher | Should -Be 'Publisher'
-        $result.QueryStatus | Should -Be 'NoActivityKql'
+        $result.QueryStatus | Should -Be 'NoKql'
     }
 
     It 'Sets IsConnected when connectivity query returns true' {
@@ -262,7 +262,7 @@ Describe 'Get-LogIngestionMetrics' {
         $result.IsConnected | Should -BeTrue
         $result.QueryStatus | Should -Be 'NoActivityKql'
     }
-]    It 'Aggregates activity query metrics and marks success' {
+    It 'Aggregates activity query metrics and marks success' {
         $wsId = [guid]::NewGuid().ToString()
         $lastLog = (Get-Date).AddMinutes(-30)
         Mock Invoke-AzOperationalInsightsQuery {
@@ -332,7 +332,8 @@ Describe 'Get-ConnectorStatus Integration' {
             
             $status = Get-ConnectorStatus -Connector $connector -WorkspaceCustomerId $wsId
             
-            $status.LogMetrics.Id | Should -Be 'different-guid-value'
+            # Resolve-Connector uses Kind as Id when Kind is meaningful (not StaticUI/GenericUI)
+            $status.LogMetrics.Id | Should -Be 'AzureActiveDirectory'
             $status.LogMetrics.Title | Should -Be 'Microsoft Entra ID'
         }
     }
@@ -373,7 +374,8 @@ Describe 'Get-ConnectorStatus missing metrics behavior' {
             $status = Get-ConnectorStatus -Connector $connector -WorkspaceCustomerId $wsId
             
             $status.OverallStatus | Should -Be 'NoKqlAndNoLogs'
-            $status.LogMetrics.QueryStatus | Should -Be 'NoActivityKql'
+            # When both ConnectivityKql and ActivityKql are missing, QueryStatus is 'NoKql'
+            $status.LogMetrics.QueryStatus | Should -Be 'NoKql'
         }
     }
 }

--- a/automation/tests/Get-DataConnectorStatus.Tests.ps1
+++ b/automation/tests/Get-DataConnectorStatus.Tests.ps1
@@ -321,18 +321,17 @@ Describe 'Get-ConnectorStatus Integration' {
             $status.LogMetrics.Publisher | Should -Be 'Microsoft'
         }
 
-        It 'Preserves Id and uses Name fallback for Title/Publisher' {
+        It 'Uses Kind as lookup Id and enriches Title/Publisher from ConnectorInfo' {
             $connector = [pscustomobject]@{ 
                 Name       = 'AzureActiveDirectory'
                 Kind       = 'AzureActiveDirectory'
-                Id         = 'different-guid-value'
                 Properties = $null
             }
             $wsId = [guid]::NewGuid().ToString()
             
             $status = Get-ConnectorStatus -Connector $connector -WorkspaceCustomerId $wsId
             
-            # Resolve-Connector uses Kind as Id when Kind is meaningful (not StaticUI/GenericUI)
+            # Resolve-Connector uses Kind as Id for ConnectorInfo lookup when Kind is meaningful
             $status.LogMetrics.Id | Should -Be 'AzureActiveDirectory'
             $status.LogMetrics.Title | Should -Be 'Microsoft Entra ID'
         }

--- a/automation/tests/Get-SentinelPricing.Tests.ps1
+++ b/automation/tests/Get-SentinelPricing.Tests.ps1
@@ -1,0 +1,320 @@
+# Pester tests for Get-SentinelPricing runbook
+# Requires: Pester 5+
+# Run with: Invoke-Pester -Path .\Get-SentinelPricing.Tests.ps1
+
+BeforeAll {
+  $env:AZLH_SKIP_PRICING_RUN = '1'
+  . "$PSScriptRoot\..\Get-SentinelPricing.ps1"
+}
+
+AfterAll {
+  Remove-Item Env:AZLH_SKIP_PRICING_RUN -ErrorAction SilentlyContinue
+}
+
+# ============================================================================
+# HELPER FUNCTION TESTS
+# ============================================================================
+
+Describe 'Assert-ValidGuid' {
+  It 'Accepts a valid GUID' {
+    { Assert-ValidGuid -value '11111111-1111-1111-1111-111111111111' -parameterName 'TestParam' } | Should -Not -Throw
+  }
+
+  It 'Rejects an invalid GUID' {
+    { Assert-ValidGuid -value 'not-a-guid' -parameterName 'TestParam' } | Should -Throw '*valid GUID*'
+  }
+}
+
+Describe 'Test-IsHttpsUri' {
+  It 'Accepts HTTPS URI' {
+    { Test-IsHttpsUri -uri 'https://example.com/path' -parameterName 'TestUri' } | Should -Not -Throw
+  }
+
+  It 'Rejects HTTP URI' {
+    { Test-IsHttpsUri -uri 'http://example.com/path' -parameterName 'TestUri' } | Should -Throw '*HTTPS*'
+  }
+
+  It 'Rejects non-absolute URI' {
+    { Test-IsHttpsUri -uri '/relative/path' -parameterName 'TestUri' } | Should -Throw '*valid URI*'
+  }
+}
+
+Describe 'Get-UriHostForLog' {
+  It 'Returns host portion only, stripping query string' {
+    $result = Get-UriHostForLog -uri 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+    $result | Should -Be 'prod-00.eastus.logic.azure.com'
+  }
+}
+
+Describe 'Get-MaskedValue' {
+  It 'Masks all but last 4 characters' {
+    $result = Get-MaskedValue -value '11111111-1111-1111-1111-111111111111'
+    $result | Should -Match '\*+1111$'
+  }
+}
+
+Describe 'Resolve-ConfiguredValue' {
+  It 'Uses parameter value before environment variable' {
+    $env:PRICINGTIER_API = 'FromEnvironment'
+    try {
+      $result = Resolve-ConfiguredValue -parameterValue 'FromParameter' -environmentVariableNames @('PRICINGTIER_API') -parameterName 'pricingTierApi'
+      $result | Should -Be 'FromParameter'
+    }
+    finally {
+      Remove-Item Env:PRICINGTIER_API -ErrorAction SilentlyContinue
+    }
+  }
+
+  It 'Uses environment variable when parameter is empty' {
+    $env:PRICINGTIER_API = 'FromEnvironment'
+    try {
+      $result = Resolve-ConfiguredValue -parameterValue '' -environmentVariableNames @('PRICINGTIER_API') -parameterName 'pricingTierApi'
+      $result | Should -Be 'FromEnvironment'
+    }
+    finally {
+      Remove-Item Env:PRICINGTIER_API -ErrorAction SilentlyContinue
+    }
+  }
+
+  It 'Throws when no value is found from any source' {
+    Remove-Item Env:PRICINGTIER_API -ErrorAction SilentlyContinue
+    { Resolve-ConfiguredValue -parameterValue '' -environmentVariableNames @('PRICINGTIER_API') -parameterName 'pricingTierApi' } | Should -Throw '*Missing required*'
+  }
+}
+
+Describe 'Get-OptionalPropertyValue' {
+  It 'Returns property value when present' {
+    $obj = [PSCustomObject]@{ Name = 'TestWorkspace' }
+    Get-OptionalPropertyValue -inputObject $obj -propertyName 'Name' | Should -Be 'TestWorkspace'
+  }
+
+  It 'Returns null when property is missing' {
+    $obj = [PSCustomObject]@{ Name = 'TestWorkspace' }
+    Get-OptionalPropertyValue -inputObject $obj -propertyName 'MissingProp' | Should -BeNullOrEmpty
+  }
+
+  It 'Returns null when object is null' {
+    Get-OptionalPropertyValue -inputObject $null -propertyName 'Name' | Should -BeNullOrEmpty
+  }
+}
+
+# ============================================================================
+# MAIN FUNCTION TESTS
+# ============================================================================
+
+Describe 'Invoke-SentinelPricingCheck' {
+  BeforeEach {
+    Mock Connect-AzAccount { }
+    Mock Set-AzContext { }
+    Mock Invoke-RestMethod { }
+  }
+
+  Context 'PerGB2018 SKU (Pay-As-You-Go)' {
+    BeforeEach {
+      Mock Get-AzOperationalInsightsWorkspace {
+        [PSCustomObject]@{
+          Name = 'law-prod'
+          Sku  = [PSCustomObject]@{ Name = 'PerGB2018' }
+        }
+      }
+    }
+
+    It 'Authenticates with UAMI and resolves Pay-As-You-Go tier' {
+      $result = Invoke-SentinelPricingCheck `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName 'law-prod' `
+        -ResourceGroupName 'rg-prod' `
+        -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+      Should -Invoke Connect-AzAccount -Times 1 -ParameterFilter { $Identity -and $AccountId -eq '11111111-1111-1111-1111-111111111111' }
+      Should -Invoke Set-AzContext -Times 1 -ParameterFilter { $SubscriptionId -eq '22222222-2222-2222-2222-222222222222' }
+      Should -Invoke Invoke-RestMethod -Times 1
+
+      $result.PricingTier | Should -Be 'Pay-As-You-Go'
+      $result.SkuName | Should -Be 'PerGB2018'
+      $result.PostStatus | Should -Be 'Success'
+      $result.RunId | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Does not POST when -WhatIf is specified' {
+      $result = Invoke-SentinelPricingCheck `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName 'law-prod' `
+        -ResourceGroupName 'rg-prod' `
+        -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret' `
+        -WhatIf
+
+      Should -Invoke Invoke-RestMethod -Times 0
+      $result.PostStatus | Should -Be 'Skipped (WhatIf)'
+      $result.PricingTier | Should -Be 'Pay-As-You-Go'
+    }
+
+    It 'Summary has expected properties' {
+      $result = Invoke-SentinelPricingCheck `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName 'law-prod' `
+        -ResourceGroupName 'rg-prod' `
+        -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+      $props = $result.PSObject.Properties.Name
+      $props | Should -Contain 'RunId'
+      $props | Should -Contain 'RunbookVersion'
+      $props | Should -Contain 'StartTimeUtc'
+      $props | Should -Contain 'EndTimeUtc'
+      $props | Should -Contain 'DurationSeconds'
+      $props | Should -Contain 'WorkspaceName'
+      $props | Should -Contain 'PricingTier'
+      $props | Should -Contain 'SkuName'
+      $props | Should -Contain 'SubscriptionId'
+      $props | Should -Contain 'ResourceGroupName'
+      $props | Should -Contain 'LogicAppHost'
+      $props | Should -Contain 'PostStatus'
+      $props | Should -Contain 'PostHttpStatus'
+    }
+
+    It 'Never logs the full Logic App URI' {
+      $logMessages = [System.Collections.Generic.List[string]]::new()
+
+      Mock Write-Information {
+        param($MessageData)
+        $logMessages.Add([string]$MessageData)
+      }
+      Mock Write-Warning {
+        param($Message)
+        $logMessages.Add([string]$Message)
+      }
+      Mock Write-Verbose {
+        param($Message)
+        $logMessages.Add([string]$Message)
+      }
+
+      Invoke-SentinelPricingCheck `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName 'law-prod' `
+        -ResourceGroupName 'rg-prod' `
+        -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=supersecrettoken123'
+
+      $allOutput = $logMessages -join "`n"
+      $allOutput | Should -Not -Match 'supersecrettoken123'
+      $allOutput | Should -Not -Match 'sig='
+    }
+  }
+
+  Context 'CapacityReservation SKU' {
+    It 'Maps CapacityReservation with level to N GB' {
+      Mock Get-AzOperationalInsightsWorkspace {
+        [PSCustomObject]@{
+          Name = 'law-prod'
+          Sku  = [PSCustomObject]@{
+            Name                     = 'CapacityReservation'
+            CapacityReservationLevel = 200
+          }
+        }
+      }
+
+      $result = Invoke-SentinelPricingCheck `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName 'law-prod' `
+        -ResourceGroupName 'rg-prod' `
+        -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+      $result.PricingTier | Should -Be '200 GB'
+      $result.SkuName | Should -Be 'CapacityReservation'
+    }
+
+    It 'Falls back to Commitment Tier when capacity level is null' {
+      Mock Get-AzOperationalInsightsWorkspace {
+        [PSCustomObject]@{
+          Name = 'law-prod'
+          Sku  = [PSCustomObject]@{ Name = 'CapacityReservation' }
+        }
+      }
+
+      $result = Invoke-SentinelPricingCheck `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName 'law-prod' `
+        -ResourceGroupName 'rg-prod' `
+        -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+      $result.PricingTier | Should -Be 'Commitment Tier'
+    }
+  }
+
+  Context 'Unknown SKU' {
+    It 'Preserves raw SKU name in output' {
+      Mock Get-AzOperationalInsightsWorkspace {
+        [PSCustomObject]@{
+          Name = 'law-prod'
+          Sku  = [PSCustomObject]@{ Name = 'Standalone' }
+        }
+      }
+
+      $result = Invoke-SentinelPricingCheck `
+        -UmiClientId '11111111-1111-1111-1111-111111111111' `
+        -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+        -WorkspaceName 'law-prod' `
+        -ResourceGroupName 'rg-prod' `
+        -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+
+      $result.PricingTier | Should -Be 'Unknown (Standalone)'
+      $result.SkuName | Should -Be 'Standalone'
+    }
+  }
+
+  Context 'Validation' {
+    BeforeEach {
+      Mock Get-AzOperationalInsightsWorkspace {
+        [PSCustomObject]@{
+          Name = 'law-prod'
+          Sku  = [PSCustomObject]@{ Name = 'PerGB2018' }
+        }
+      }
+    }
+
+    It 'Throws on invalid UmiClientId GUID' {
+      { Invoke-SentinelPricingCheck `
+          -UmiClientId 'not-a-guid' `
+          -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+          -WorkspaceName 'law-prod' `
+          -ResourceGroupName 'rg-prod' `
+          -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+      } | Should -Throw '*valid GUID*'
+    }
+
+    It 'Throws on invalid SubscriptionId GUID' {
+      { Invoke-SentinelPricingCheck `
+          -UmiClientId '11111111-1111-1111-1111-111111111111' `
+          -SubscriptionId 'bad-sub' `
+          -WorkspaceName 'law-prod' `
+          -ResourceGroupName 'rg-prod' `
+          -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+      } | Should -Throw '*valid GUID*'
+    }
+
+    It 'Throws on HTTP (non-HTTPS) Logic App URI' {
+      { Invoke-SentinelPricingCheck `
+          -UmiClientId '11111111-1111-1111-1111-111111111111' `
+          -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+          -WorkspaceName 'law-prod' `
+          -ResourceGroupName 'rg-prod' `
+          -PricingTierApi 'http://insecure.example.com/workflows/abc'
+      } | Should -Throw '*HTTPS*'
+    }
+
+    It 'Throws on missing required value' {
+      { Invoke-SentinelPricingCheck `
+          -UmiClientId '11111111-1111-1111-1111-111111111111' `
+          -SubscriptionId '22222222-2222-2222-2222-222222222222' `
+          -WorkspaceName '' `
+          -ResourceGroupName 'rg-prod' `
+          -PricingTierApi 'https://prod-00.eastus.logic.azure.com/workflows/abc?sig=secret'
+      } | Should -Throw '*Missing required*'
+    }
+  }
+}


### PR DESCRIPTION
Add Get-AzurePolicies and Get-SentinelPricing runbooks.
Implement comprehensive Pester tests for Get-AzurePolicies and Get-SentinelPricing runbooks, ensuring robust validation of expected behaviors. Refactor the README and update automation account JSON with new API versions while improving test descriptions for clarity. 
Enhance error logging for Logic App POST failures to include specific URI and SAS token validity checks.