### PR TITLE
Update allowedValues mapping for User Assigned Managed Identity selection

### DIFF
--- a/automation/createUiDefinition.json
+++ b/automation/createUiDefinition.json
@@ -52,7 +52,7 @@
         "toolTip": "Select an existing User Assigned Managed Identity in the resource group chosen on the Basics tab.",
         "multiselect": false,
         "constraints": {
-          "allowedValues": "[map(basics('umiListApi').value, (item) => createObject('label', item.name, 'value', item.name))]",
+          "allowedValues": "[map(basics('umiListApi').value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
           "required": true
         }
       },


### PR DESCRIPTION
Refactor the allowedValues mapping in createUiDefinition.json to ensure proper JSON formatting for User Assigned Managed Identity selection.